### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,6 +27,8 @@ jobs:
   test:
     name: Run Unit & Integration Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mauv0809/ideal-tribble/security/code-scanning/1](https://github.com/mauv0809/ideal-tribble/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `test` job in the workflow file. This block should explicitly set `contents: read`, which is the minimal permission required for the job to check out the code and run tests. This change ensures that the job does not inherit potentially excessive permissions from the repository or organization defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
