### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unified-deploy.yml
+++ b/.github/workflows/unified-deploy.yml
@@ -57,6 +57,8 @@ jobs:
   # Deploy infrastructure (runs in parallel with build)
   terraform-apply:
     name: Deploy Infrastructure
+    permissions:
+      contents: read
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
Potential fix for [https://github.com/mauv0809/ideal-tribble/security/code-scanning/11](https://github.com/mauv0809/ideal-tribble/security/code-scanning/11)

To fix the problem, we need to add a `permissions` key to the `terraform-apply` job definition in `.github/workflows/unified-deploy.yml`, limiting permissions to the minimal required for the job. Since all steps in `terraform-apply` only require reading repository contents (for code checkout), restricting permissions to `contents: read` is usually sufficient. No steps require write access to contents or other privileged scopes. To implement the fix, modify the `terraform-apply` job declaration by inserting:
```yaml
permissions:
  contents: read
```
directly below the `name:` key of this job. No other imports, definitions, or method changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
