### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unified-deploy.yml
+++ b/.github/workflows/unified-deploy.yml
@@ -146,6 +146,8 @@ jobs:
     name: Deploy Application
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [build, terraform-apply]
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/mauv0809/ideal-tribble/security/code-scanning/9](https://github.com/mauv0809/ideal-tribble/security/code-scanning/9)

The best way to fix this issue is to add an explicit `permissions` block to the affected job (`deploy-application`) restricting the GITHUB_TOKEN to only the privileges needed. For typical deployment jobs that only need to read repository contents (e.g., for code checkout), `contents: read` is sufficient as a starting point. The change should only affect the configuration for this job and should not impact any of its functionality. The edit must be made in `.github/workflows/unified-deploy.yml`, by adding the following block in the `deploy-application` job definition:

```yaml
permissions:
  contents: read
```

This should be inserted under `runs-on: ubuntu-latest` and above `steps:` in the `deploy-application` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
