### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unified-deploy.yml
+++ b/.github/workflows/unified-deploy.yml
@@ -41,6 +41,8 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mauv0809/ideal-tribble/security/code-scanning/5](https://github.com/mauv0809/ideal-tribble/security/code-scanning/5)

To fix the problem, specify the least-permissive required permissions explicitly for the `test` job. The `test` job only checks out code and runs Go tests, which means it only needs to be able to read repository contents. Therefore, add a `permissions` block under `test:` with `contents: read`. This does not change the actual functionality—checkout actions and test running will proceed as before—but it ensures the workflow cannot accidentally (or maliciously, if abused) write to the repository or escalate privileges using the GITHUB_TOKEN. The change is simply to insert the correct YAML block below the `runs-on:` line for the `test` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
